### PR TITLE
Fix the configmap in the helm chart

### DIFF
--- a/deployments/loader/templates/configmap.yaml
+++ b/deployments/loader/templates/configmap.yaml
@@ -33,7 +33,10 @@ data:
     {{- range .Values.baseModels }}
     - {{ . }}
     {{- end }}
-    models: {{- toYaml .Values.models | nindent 4 }}
+    models:
+    {{- range .Values.models }}
+    - {{ . }}
+    {{- end }}
     modelLoadInterval: {{ .Values.modelLoadInterval }}
     runOnce: {{ .Values.runOnce }}
     modelManagerServerWorkerServiceAddr: {{ .Values.global.worker.controlPlaneAddr | default .Values.modelManagerServerWorkerServiceAddr }}


### PR DESCRIPTION
Got "Error: config: unmarshal: yaml: line 25: could not find expected ':'" when the models is empty in the values.yaml