### PR TITLE
fix(deployments): remove duplicated annotation definitions

### DIFF
--- a/deployments/server/templates/deployment.yaml
+++ b/deployments/server/templates/deployment.yaml
@@ -15,8 +15,6 @@ spec:
         {{- include "model-manager-server.selectorLabels" . | nindent 8 }}
       annotations:
         checksum/config: {{ sha256sum (toJson .Values) }}
-      annotations:
-        checksum/config: {{ sha256sum (toJson .Values) }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
Hit an error when trying Kustomize as it doesn't allow duplicated keys.