### PR TITLE
fix(chart): run loader as a Job in runOnce mode

### DIFF
--- a/deployments/loader/templates/deployment.yaml
+++ b/deployments/loader/templates/deployment.yaml
@@ -1,14 +1,21 @@
+{{- if .Values.runOnce }}
+apiVersion: batch/v1
+kind: Job
+{{- else }}
 apiVersion: apps/v1
 kind: Deployment
+{{- end }}
 metadata:
   name: {{ include "model-manager-loader.fullname" . }}
   labels:
     {{- include "model-manager-loader.labels" . | nindent 4 }}
 spec:
+  {{- if not .Values.runOnce }}
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       {{- include "model-manager-loader.selectorLabels" . | nindent 6 }}
+  {{- end }}
   template:
     metadata:
       labels:
@@ -19,6 +26,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.runOnce }}
+      restartPolicy: Never
+      {{- end }}
       serviceAccountName: {{ include "model-manager-loader.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
@@ -92,7 +102,7 @@ spec:
       - name: config
         configMap:
           name: {{ include "model-manager-loader.fullname" . }}
-      - name: tmp          
+      - name: tmp
       {{- if .Values.persistentVolume.enabled }}
         persistentVolumeClaim:
           claimName: {{ .Values.persistentVolume.existingClaim | default (include "model-manager-loader.fullname" .) }}


### PR DESCRIPTION
runOnce mode will complete after the specified models have been loaded, but if we run it as the Deployment, it will restart and crash.