### PR TITLE
fix(loader): use the original model name from ollama as the modelID

### DIFF
--- a/loader/internal/loader/loader.go
+++ b/loader/internal/loader/loader.go
@@ -534,9 +534,8 @@ func buildModelIDForGGUF(modelID, ggufModelFilePath string) string {
 
 func toLLMarinerModelID(id string) string {
 	// HuggingFace uses '/' as a separator, but Ollama does not accept. Use '-' instead for now.
-	// Ollama uses ':' as a separator, it cannot be used for bucket name. Use '-' instead.
 	// TODO(kenji): Revisit this.
-	return strings.ReplaceAll(strings.ReplaceAll(id, "/", "-"), ":", "-")
+	return strings.ReplaceAll(id, "/", "-")
 }
 
 // splitHFRepoAndFile returns the HuggingFace repo name and the filename to be downloaded.

--- a/loader/internal/loader/loader_test.go
+++ b/loader/internal/loader/loader_test.go
@@ -141,7 +141,7 @@ func TestLoadBaseModel_Ollama(t *testing.T) {
 	assert.ElementsMatch(t, want, s3Client.uploadedKeys)
 
 	got, err := mc.GetBaseModelPath(context.Background(), &mv1.GetBaseModelPathRequest{
-		Id: "gemma-2b",
+		Id: "gemma:2b",
 	})
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []mv1.ModelFormat{mv1.ModelFormat_MODEL_FORMAT_OLLAMA}, got.Formats)


### PR DESCRIPTION
The converted name will continue to be used for s3 path name.