### PR TITLE
feat: support base model deletion

### DIFF
--- a/server/internal/server/models_test.go
+++ b/server/internal/server/models_test.go
@@ -72,8 +72,17 @@ func TestDeleteModel_BaseModel(t *testing.T) {
 	_, err = srv.DeleteModel(ctx, &v1.DeleteModelRequest{
 		Id: "m0",
 	})
+	assert.NoError(t, err)
+
+	_, err = srv.GetModel(ctx, &v1.GetModelRequest{
+		Id: "m0",
+	})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Equal(t, codes.NotFound, status.Code(err))
+
+	listResp, err := srv.ListModels(ctx, &v1.ListModelsRequest{})
+	assert.NoError(t, err)
+	assert.Len(t, listResp.Data, 0)
 }
 
 func TestGetAndListModels(t *testing.T) {

--- a/server/internal/store/base_model.go
+++ b/server/internal/store/base_model.go
@@ -60,6 +60,18 @@ func (s *S) CreateBaseModel(
 	return m, nil
 }
 
+// DeleteBaseModel deletes a base model by model ID and tenant ID.
+func (s *S) DeleteBaseModel(modelID, tenantID string) error {
+	res := s.db.Where("model_id = ? AND tenant_id = ?", modelID, tenantID).Delete(&BaseModel{})
+	if err := res.Error; err != nil {
+		return err
+	}
+	if res.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
+}
+
 // GetBaseModel returns a base model by model ID and tenant ID.
 func (s *S) GetBaseModel(modelID, tenantID string) (*BaseModel, error) {
 	var m BaseModel

--- a/server/internal/store/base_model_test.go
+++ b/server/internal/store/base_model_test.go
@@ -64,5 +64,28 @@ func TestBaseModel_UniqueConstraint(t *testing.T) {
 
 	_, err = st.CreateBaseModel("m1", "path", []v1.ModelFormat{v1.ModelFormat_MODEL_FORMAT_GGUF}, "gguf_model_path", "t0")
 	assert.NoError(t, err)
+}
 
+func TestDeleteBaseModel(t *testing.T) {
+	st, tearDown := NewTest(t)
+	defer tearDown()
+
+	const (
+		modelID  = "m0"
+		tenantID = "t0"
+	)
+
+	_, err := st.CreateBaseModel(modelID, "path", []v1.ModelFormat{v1.ModelFormat_MODEL_FORMAT_GGUF}, "gguf_model_path", tenantID)
+	assert.NoError(t, err)
+
+	err = st.DeleteBaseModel(modelID, tenantID)
+	assert.NoError(t, err)
+
+	_, err = st.GetBaseModel(modelID, tenantID)
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, gorm.ErrRecordNotFound))
+
+	err = st.DeleteBaseModel(modelID, tenantID)
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, gorm.ErrRecordNotFound))
 }


### PR DESCRIPTION
It makes sense to allow end users o delete base models that are no longer needed.

On the other hand, as currently base models are created per tenant (not project), the permission check we have not is sufficient.

Implementing the functionality now, but the permission check should be revisited.