### PR TITLE
fix: always mount '/.ollama'

### DIFF
--- a/deployments/loader/templates/deployment.yaml
+++ b/deployments/loader/templates/deployment.yaml
@@ -48,10 +48,8 @@ spec:
           readOnly: true
         - name: tmp
           mountPath: /tmp
-        {{- if eq .Values.downloader.kind "ollama" }}
         - name: tmp
           mountPath: /.ollama
-        {{- end }}
         {{- with .Values.volumeMounts }}
         {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
To support dynamic model loading. Even if the kind is not set to ollama, we would like to download from Ollama when requested.