### PR TITLE
chore: Delete the ListBaseModels RPC

### DIFF
--- a/api/v1/model_manager_service.proto
+++ b/api/v1/model_manager_service.proto
@@ -123,20 +123,6 @@ message DeleteModelResponse {
   bool deleted = 3;
 }
 
-message ListBaseModelsRequest {
-}
-
-message BaseModel {
-  string id = 1;
-  int64 created = 2;
-  string object = 3;
-}
-
-message ListBaseModelsResponse {
-  string object = 1;
-  repeated BaseModel data = 2;
-}
-
 service ModelsService {
 
   rpc ListModels(ListModelsRequest) returns (ListModelsResponse) {
@@ -167,18 +153,12 @@ service ModelsService {
 
   // The following API endpoints are not part of the OpenAPI API specification.
 
-  // CreateModel creates a new base model. The model becomes available once
+  // CreateModel creates a new model. The model becomes available once
   // its model file is loaded to an object store.
   rpc CreateModel(CreateModelRequest) returns (Model) {
     option (google.api.http) = {
       post: "/v1/models"
       body: "*"
-    };
-  }
-
-  rpc ListBaseModels(ListBaseModelsRequest) returns (ListBaseModelsResponse) {
-    option (google.api.http) = {
-      get: "/v1/basemodels"
     };
   }
 

--- a/deployments/server/templates/ingress.yaml
+++ b/deployments/server/templates/ingress.yaml
@@ -28,13 +28,6 @@ spec:
             name: {{ include "model-manager-server.fullname" . }}-http
             port:
               number: {{ .Values.httpPort }}
-      - path: /v1/basemodels
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ include "model-manager-server.fullname" . }}-http
-            port:
-              number: {{ .Values.httpPort }}
 
 ---
 

--- a/server/internal/server/models.go
+++ b/server/internal/server/models.go
@@ -315,30 +315,6 @@ func (s *S) DeleteModel(
 	}, nil
 }
 
-// ListBaseModels lists base models.
-func (s *S) ListBaseModels(
-	ctx context.Context,
-	req *v1.ListBaseModelsRequest,
-) (*v1.ListBaseModelsResponse, error) {
-	userInfo, ok := auth.ExtractUserInfoFromContext(ctx)
-	if !ok {
-		return nil, fmt.Errorf("failed to extract user info from context")
-	}
-
-	ms, err := s.store.ListBaseModels(userInfo.TenantID)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "list base models: %s", err)
-	}
-	var modelProtos []*v1.BaseModel
-	for _, m := range ms {
-		modelProtos = append(modelProtos, toBaseModelProto(m))
-	}
-	return &v1.ListBaseModelsResponse{
-		Object: "list",
-		Data:   modelProtos,
-	}, nil
-}
-
 // GetModel gets a model.
 func (s *WS) GetModel(
 	ctx context.Context,

--- a/server/internal/server/models_test.go
+++ b/server/internal/server/models_test.go
@@ -554,9 +554,7 @@ func TestBaseModels(t *testing.T) {
 	st, tearDown := store.NewTest(t)
 	defer tearDown()
 
-	srv := New(st, testr.New(t))
 	ctx := fakeAuthInto(context.Background())
-
 	wsrv := NewWorkerServiceServer(st, testr.New(t))
 
 	const modelID = "m0"
@@ -566,10 +564,6 @@ func TestBaseModels(t *testing.T) {
 	})
 	assert.Error(t, err)
 	assert.Equal(t, codes.NotFound, status.Code(err))
-
-	listResp, err := srv.ListBaseModels(ctx, &v1.ListBaseModelsRequest{})
-	assert.NoError(t, err)
-	assert.Len(t, listResp.Data, 0)
 
 	// Create a base model.
 	_, err = wsrv.CreateBaseModel(ctx, &v1.CreateBaseModelRequest{


### PR DESCRIPTION
This was added by https://github.com/llmariner/model-manager/pull/27, and we don't use.