### PR TITLE
feat: make models unique by model ID and tenant ID

### DIFF
--- a/server/internal/server/models_test.go
+++ b/server/internal/server/models_test.go
@@ -428,7 +428,7 @@ func TestRegisterAndPublishModel(t *testing.T) {
 	modelID := resp.Id
 	assert.True(t, strings.HasPrefix(modelID, "ft:my-model:fine-tuning-"))
 
-	m, err := st.GetModelByModelID(modelID)
+	m, err := st.GetModelByModelIDAndTenantID(modelID, defaultTenantID)
 	assert.NoError(t, err)
 	assert.False(t, m.IsPublished)
 

--- a/server/internal/store/model.go
+++ b/server/internal/store/model.go
@@ -9,10 +9,9 @@ import (
 type Model struct {
 	gorm.Model
 
-	// ModelID is the model ID. It is globally unique.
-	ModelID string `gorm:"uniqueIndex"`
+	TenantID string `gorm:"uniqueIndex:idx_model_model_id_tenant_id"`
+	ModelID  string `gorm:"uniqueIndex:idx_model_model_id_tenant_id"`
 
-	TenantID       string `gorm:"index"`
 	OrganizationID string
 	ProjectID      string `gorm:"index"`
 
@@ -60,28 +59,19 @@ func (s *S) CreateModel(spec ModelSpec) (*Model, error) {
 	return m, nil
 }
 
-// GetPublishedModelByModelIDAndProjectID returns a published model by model ID and tenant ID.
-func (s *S) GetPublishedModelByModelIDAndProjectID(modelID, projectID string) (*Model, error) {
-	var m Model
-	if err := s.db.Where("model_id = ? AND project_id = ? AND is_published = ? ", modelID, projectID, true).Take(&m).Error; err != nil {
-		return nil, err
-	}
-	return &m, nil
-}
-
-// GetModelByModelID returns a model by model ID.
-func (s *S) GetModelByModelID(modelID string) (*Model, error) {
-	var m Model
-	if err := s.db.Where("model_id = ?", modelID).Take(&m).Error; err != nil {
-		return nil, err
-	}
-	return &m, nil
-}
-
-// GetPublishedModelByModelIDAndTenantID returns a model by model ID.
+// GetPublishedModelByModelIDAndTenantID returns a published model by model ID and tenant ID.
 func (s *S) GetPublishedModelByModelIDAndTenantID(modelID, tenantID string) (*Model, error) {
 	var m Model
-	if err := s.db.Where("model_id = ? AND tenant_id = ? AND is_published = ?", modelID, tenantID, true).Take(&m).Error; err != nil {
+	if err := s.db.Where("model_id = ? AND tenant_id = ? AND is_published = ? ", modelID, tenantID, true).Take(&m).Error; err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+// GetModelByModelIDAndTenantID returns a model by model ID and tenant ID.
+func (s *S) GetModelByModelIDAndTenantID(modelID, tenantID string) (*Model, error) {
+	var m Model
+	if err := s.db.Where("model_id = ? AND tenant_id = ?", modelID, tenantID).Take(&m).Error; err != nil {
 		return nil, err
 	}
 	return &m, nil
@@ -119,8 +109,8 @@ func (s *S) ListModelsByProjectIDWithPagination(
 }
 
 // DeleteModel deletes a model by model ID and tenant ID.
-func (s *S) DeleteModel(modelID, projectID string) error {
-	res := s.db.Unscoped().Where("model_id = ? AND project_id = ?", modelID, projectID).Delete(&Model{})
+func (s *S) DeleteModel(modelID, tenantID string) error {
+	res := s.db.Unscoped().Where("model_id = ? AND tenant_id = ?", modelID, tenantID).Delete(&Model{})
 	if err := res.Error; err != nil {
 		return err
 	}

--- a/server/internal/store/model_test.go
+++ b/server/internal/store/model_test.go
@@ -87,7 +87,7 @@ func TestModel(t *testing.T) {
 	assert.False(t, hasMore)
 	assert.Equal(t, m0.ID, gotMs[0].ID)
 
-	err = st.DeleteModel(modelID, projectID)
+	err = st.DeleteModel(modelID, tenantID)
 	assert.NoError(t, err)
 
 	gotMs, hasMore, err = st.ListModelsByProjectIDWithPagination(projectID, true, "", defaultPageSize, true)
@@ -95,7 +95,7 @@ func TestModel(t *testing.T) {
 	assert.Len(t, gotMs, 1)
 	assert.False(t, hasMore)
 
-	err = st.DeleteModel(modelID, projectID)
+	err = st.DeleteModel(modelID, tenantID)
 	assert.True(t, errors.Is(err, gorm.ErrRecordNotFound))
 }
 
@@ -192,20 +192,20 @@ func TestUpdateModel(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	got, err := st.GetModelByModelID(modelID)
+	got, err := st.GetModelByModelIDAndTenantID(modelID, tenantID)
 	assert.NoError(t, err)
 	assert.False(t, got.IsPublished)
 
 	err = st.UpdateModel(modelID, tenantID, true, v1.ModelLoadingStatus_MODEL_LOADING_STATUS_SUCCEEDED)
 	assert.NoError(t, err)
-	got, err = st.GetModelByModelID(modelID)
+	got, err = st.GetModelByModelIDAndTenantID(modelID, tenantID)
 	assert.NoError(t, err)
 	assert.True(t, got.IsPublished)
 	assert.Equal(t, got.LoadingStatus, v1.ModelLoadingStatus_MODEL_LOADING_STATUS_SUCCEEDED)
 
 	err = st.UpdateModel(modelID, tenantID, false, v1.ModelLoadingStatus_MODEL_LOADING_STATUS_SUCCEEDED)
 	assert.NoError(t, err)
-	got, err = st.GetModelByModelID(modelID)
+	got, err = st.GetModelByModelIDAndTenantID(modelID, tenantID)
 	assert.NoError(t, err)
 	assert.False(t, got.IsPublished)
 }


### PR DESCRIPTION
We will allow end users to create a fine-tuned models. In such a case, we cannot guarantee that model IDs are globally unique.

We cannot also make model IDs unique per project ID as inference-manager-engine needs to access models.