### PR TITLE
chore: make downloadAndUploadModel take modelPath as a separate argument

### DIFF
--- a/loader/internal/loader/hugging_face_downloader.go
+++ b/loader/internal/loader/hugging_face_downloader.go
@@ -24,13 +24,13 @@ type HuggingFaceDownloader struct {
 	log      logr.Logger
 }
 
-func (h *HuggingFaceDownloader) download(ctx context.Context, modelName, filename, destDir string) error {
+func (h *HuggingFaceDownloader) download(ctx context.Context, modelPath, filename, destDir string) error {
 	// Download the image with huggingface-cli. If the access to the specified model is gated,
 	// the environment variable HUGGING_FACE_HUB_TOKEN needs to be set.
 	cmdline := []string{
 		"huggingface-cli",
 		"download",
-		modelName,
+		modelPath,
 	}
 	if filename != "" {
 		cmdline = append(cmdline, filename)

--- a/loader/internal/loader/loader.go
+++ b/loader/internal/loader/loader.go
@@ -20,7 +20,7 @@ import (
 
 // ModelDownloader is an interface for downloading a model.
 type ModelDownloader interface {
-	download(ctx context.Context, modelName, filename, destDir string) error
+	download(ctx context.Context, modelPath, filename, destDir string) error
 }
 
 // modelDownloaderFactory is the factory for ModelDownloader.
@@ -217,7 +217,7 @@ func (l *L) loadBaseModel(ctx context.Context, modelID string, sourceRepository 
 	}
 
 	pathPrefix := filepath.Join(l.objectStorePathPrefix, l.baseModelPathPrefix, toKeyModelID(modelIDToDownload))
-	modelInfos, err := l.downloadAndUploadModel(ctx, modelIDToDownload, filename, sourceRepository, pathPrefix)
+	modelInfos, err := l.downloadAndUploadModel(ctx, modelIDToDownload, modelIDToDownload, filename, sourceRepository, pathPrefix)
 	if err != nil {
 		return err
 	}
@@ -281,7 +281,7 @@ func (l *L) loadModelFromConfig(ctx context.Context, model config.ModelConfig, s
 
 	// TODO(guangrui): make tenant-id configurable. The path should match with the path generated in RegisterModel.
 	pathPrefix := filepath.Join(l.objectStorePathPrefix, tenantID, toKeyModelID(model.Model))
-	modelInfos, err := l.downloadAndUploadModel(ctx, model.Model, "", sourceRepository, pathPrefix)
+	modelInfos, err := l.downloadAndUploadModel(ctx, model.Model, model.Model, "", sourceRepository, pathPrefix)
 	if err != nil {
 		return err
 	}
@@ -321,6 +321,7 @@ type modelInfo struct {
 func (l *L) downloadAndUploadModel(
 	ctx context.Context,
 	modelID,
+	modelPath,
 	filename string,
 	sourceRepository v1.SourceRepository,
 	pathPrefix string,
@@ -351,7 +352,7 @@ func (l *L) downloadAndUploadModel(
 	if err != nil {
 		return nil, err
 	}
-	if err := downloader.download(ctx, modelID, filename, tmpDir); err != nil {
+	if err := downloader.download(ctx, modelPath, filename, tmpDir); err != nil {
 		return nil, err
 	}
 

--- a/loader/internal/loader/loader_test.go
+++ b/loader/internal/loader/loader_test.go
@@ -502,7 +502,7 @@ type fakeDownloader struct {
 	files []string
 }
 
-func (d *fakeDownloader) download(ctx context.Context, modelName, filename string, destDir string) error {
+func (d *fakeDownloader) download(ctx context.Context, modelPath, filename string, destDir string) error {
 	for _, d := range d.dirs {
 		if err := os.MkdirAll(filepath.Join(destDir, d), 0755); err != nil {
 			return err

--- a/loader/internal/loader/ollama_downloader.go
+++ b/loader/internal/loader/ollama_downloader.go
@@ -51,7 +51,7 @@ func (o *OllamaDownloader) waitForReady(ctx context.Context) error {
 	}
 }
 
-func (o *OllamaDownloader) download(ctx context.Context, modelName, filename, destDir string) error {
+func (o *OllamaDownloader) download(ctx context.Context, modelPath, filename, destDir string) error {
 	if err := os.Setenv("OLLAMA_HOST", fmt.Sprintf("0.0.0.0:%d", o.port)); err != nil {
 		return err
 	}
@@ -70,7 +70,7 @@ func (o *OllamaDownloader) download(ctx context.Context, modelName, filename, de
 	if err := o.waitForReady(ctx); err != nil {
 		return err
 	}
-	return o.runCommand(ctx, "pull", modelName)
+	return o.runCommand(ctx, "pull", modelPath)
 }
 
 func (o *OllamaDownloader) runCommand(ctx context.Context, args ...string) error {

--- a/loader/internal/loader/s3_downloader.go
+++ b/loader/internal/loader/s3_downloader.go
@@ -33,11 +33,15 @@ type S3Downloader struct {
 	pathPrefix string
 }
 
-func (d *S3Downloader) download(ctx context.Context, modelName, filename, destDir string) error {
-	d.log.Info("Downloading the model", "name", modelName)
+func (d *S3Downloader) download(ctx context.Context, modelPath, filename, destDir string) error {
+	d.log.Info("Downloading the model", "modelPath", modelPath)
 
 	var keys []string
-	prefix := filepath.Join(d.pathPrefix, modelName)
+	// Use pathPrefix if the model name does not start with "s3://".
+	prefix := modelPath
+	if !strings.HasPrefix(modelPath, "s3://") {
+		prefix = filepath.Join(d.pathPrefix, modelPath)
+	}
 	f := func(page *s3.ListObjectsV2Output, lastPage bool) bool {
 		for _, obj := range page.Contents {
 			if filename != "" && *obj.Key != filepath.Join(prefix, filename) {


### PR DESCRIPTION
For upcoming change to support upload of fine-tuned models.