### PR TITLE
fix(ci-post-merge.yml): run `softprops/action-gh-release` with the `target_commitish` option set

### DIFF
--- a/.github/workflows/ci-post-merge.yml
+++ b/.github/workflows/ci-post-merge.yml
@@ -116,4 +116,5 @@ jobs:
       uses: softprops/action-gh-release@v2.0.8
       with:
         tag_name: v${{ env.version }}
+        target_commitish: ${{ github.sha }}
         generate_release_notes: true


### PR DESCRIPTION
See https://github.com/llmariner/inference-manager/pull/694

https://cloudnatix.atlassian.net/browse/CNATIX-5916