### PR TITLE
Feat(ListModelSorting): Sort models by active then base model

### DIFF
--- a/server/internal/server/models.go
+++ b/server/internal/server/models.go
@@ -209,22 +209,22 @@ func (s *S) ListModels(
 		if err != nil {
 			return nil, err
 		}
-		var status v1.ActivationStatus
+		var as v1.ActivationStatus
 		var isBase bool
 		if bm != nil {
-			status, err = getModelActivationStatus(s.store, bm.ModelID, bm.TenantID)
+			as, err = getModelActivationStatus(s.store, bm.ModelID, bm.TenantID)
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "get model activation status: %s", err)
 			}
 			isBase = true
 		} else {
-			status, err = getModelActivationStatus(s.store, m.ModelID, m.TenantID)
+			as, err = getModelActivationStatus(s.store, m.ModelID, m.TenantID)
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "get model activation status: %s", err)
 			}
 			isBase = false
 		}
-		startCat = activationCategory(isBase, status)
+		startCat = activationCategory(isBase, as)
 		afterID = req.After
 	}
 

--- a/server/internal/server/models_test.go
+++ b/server/internal/server/models_test.go
@@ -175,6 +175,65 @@ func TestModels_Pagination(t *testing.T) {
 	}
 }
 
+func TestListModels_ActivationOrder(t *testing.T) {
+	st, tearDown := store.NewTest(t)
+	defer tearDown()
+
+	// Create base models.
+	_, err := st.CreateBaseModel(
+		"bm0",
+		"path",
+		[]v1.ModelFormat{v1.ModelFormat_MODEL_FORMAT_GGUF},
+		"gguf-path",
+		v1.SourceRepository_SOURCE_REPOSITORY_OBJECT_STORE,
+		defaultTenantID,
+	)
+	assert.NoError(t, err)
+	_, err = st.CreateBaseModel(
+		"bm1",
+		"path",
+		[]v1.ModelFormat{v1.ModelFormat_MODEL_FORMAT_GGUF},
+		"gguf-path",
+		v1.SourceRepository_SOURCE_REPOSITORY_OBJECT_STORE,
+		defaultTenantID,
+	)
+	assert.NoError(t, err)
+
+	// Create fine tuned models.
+	for _, id := range []string{"m0", "m1"} {
+		_, err := st.CreateModel(store.ModelSpec{
+			ModelID:        id,
+			OrganizationID: "o0",
+			ProjectID:      defaultProjectID,
+			TenantID:       defaultTenantID,
+			IsPublished:    true,
+			LoadingStatus:  v1.ModelLoadingStatus_MODEL_LOADING_STATUS_SUCCEEDED,
+		})
+		assert.NoError(t, err)
+	}
+
+	// Activation statuses
+	err = st.CreateModelActivationStatus(&store.ModelActivationStatus{ModelID: "bm0", TenantID: defaultTenantID, Status: v1.ActivationStatus_ACTIVATION_STATUS_ACTIVE})
+	assert.NoError(t, err)
+	err = st.CreateModelActivationStatus(&store.ModelActivationStatus{ModelID: "m0", TenantID: defaultTenantID, Status: v1.ActivationStatus_ACTIVATION_STATUS_ACTIVE})
+	assert.NoError(t, err)
+	err = st.CreateModelActivationStatus(&store.ModelActivationStatus{ModelID: "bm1", TenantID: defaultTenantID, Status: v1.ActivationStatus_ACTIVATION_STATUS_INACTIVE})
+	assert.NoError(t, err)
+	err = st.CreateModelActivationStatus(&store.ModelActivationStatus{ModelID: "m1", TenantID: defaultTenantID, Status: v1.ActivationStatus_ACTIVATION_STATUS_INACTIVE})
+	assert.NoError(t, err)
+
+	srv := New(st, testr.New(t))
+	ctx := fakeAuthInto(context.Background())
+
+	resp, err := srv.ListModels(ctx, &v1.ListModelsRequest{})
+	assert.NoError(t, err)
+	var ids []string
+	for _, m := range resp.Data {
+		ids = append(ids, m.Id)
+	}
+	assert.Equal(t, []string{"bm0", "m0", "bm1", "m1"}, ids)
+}
+
 func TestDeleteModel_BaseModel(t *testing.T) {
 	st, tearDown := store.NewTest(t)
 	defer tearDown()

--- a/server/internal/server/models_test.go
+++ b/server/internal/server/models_test.go
@@ -175,65 +175,6 @@ func TestModels_Pagination(t *testing.T) {
 	}
 }
 
-func TestListModels_ActivationOrder(t *testing.T) {
-	st, tearDown := store.NewTest(t)
-	defer tearDown()
-
-	// Create base models.
-	_, err := st.CreateBaseModel(
-		"bm0",
-		"path",
-		[]v1.ModelFormat{v1.ModelFormat_MODEL_FORMAT_GGUF},
-		"gguf-path",
-		v1.SourceRepository_SOURCE_REPOSITORY_OBJECT_STORE,
-		defaultTenantID,
-	)
-	assert.NoError(t, err)
-	_, err = st.CreateBaseModel(
-		"bm1",
-		"path",
-		[]v1.ModelFormat{v1.ModelFormat_MODEL_FORMAT_GGUF},
-		"gguf-path",
-		v1.SourceRepository_SOURCE_REPOSITORY_OBJECT_STORE,
-		defaultTenantID,
-	)
-	assert.NoError(t, err)
-
-	// Create fine tuned models.
-	for _, id := range []string{"m0", "m1"} {
-		_, err := st.CreateModel(store.ModelSpec{
-			ModelID:        id,
-			OrganizationID: "o0",
-			ProjectID:      defaultProjectID,
-			TenantID:       defaultTenantID,
-			IsPublished:    true,
-			LoadingStatus:  v1.ModelLoadingStatus_MODEL_LOADING_STATUS_SUCCEEDED,
-		})
-		assert.NoError(t, err)
-	}
-
-	// Activation statuses
-	err = st.CreateModelActivationStatus(&store.ModelActivationStatus{ModelID: "bm0", TenantID: defaultTenantID, Status: v1.ActivationStatus_ACTIVATION_STATUS_ACTIVE})
-	assert.NoError(t, err)
-	err = st.CreateModelActivationStatus(&store.ModelActivationStatus{ModelID: "m0", TenantID: defaultTenantID, Status: v1.ActivationStatus_ACTIVATION_STATUS_ACTIVE})
-	assert.NoError(t, err)
-	err = st.CreateModelActivationStatus(&store.ModelActivationStatus{ModelID: "bm1", TenantID: defaultTenantID, Status: v1.ActivationStatus_ACTIVATION_STATUS_INACTIVE})
-	assert.NoError(t, err)
-	err = st.CreateModelActivationStatus(&store.ModelActivationStatus{ModelID: "m1", TenantID: defaultTenantID, Status: v1.ActivationStatus_ACTIVATION_STATUS_INACTIVE})
-	assert.NoError(t, err)
-
-	srv := New(st, testr.New(t))
-	ctx := fakeAuthInto(context.Background())
-
-	resp, err := srv.ListModels(ctx, &v1.ListModelsRequest{})
-	assert.NoError(t, err)
-	var ids []string
-	for _, m := range resp.Data {
-		ids = append(ids, m.Id)
-	}
-	assert.Equal(t, []string{"bm0", "m0", "bm1", "m1"}, ids)
-}
-
 func TestDeleteModel_BaseModel(t *testing.T) {
 	st, tearDown := store.NewTest(t)
 	defer tearDown()

--- a/server/internal/store/base_model.go
+++ b/server/internal/store/base_model.go
@@ -176,18 +176,6 @@ func (s *S) ListBaseModelsWithPagination(tenantID string, afterModelID string, l
 	return ms, hasMore, nil
 }
 
-// ListBaseModelsByActivationStatusWithPagination finds base models filtered by activation status with pagination.
-// Models are returned with an ascending order of model IDs.
-func (s *S) ListBaseModelsByActivationStatusWithPagination(
-	tenantID string,
-	status v1.ActivationStatus,
-	afterModelID string,
-	limit int,
-	includeLoadingModels bool,
-) ([]*BaseModel, bool, error) {
-	return ListBaseModelsByActivationStatusWithPaginationInTransaction(s.db, tenantID, status, afterModelID, limit, includeLoadingModels)
-}
-
 // ListBaseModelsByActivationStatusWithPaginationInTransaction finds base models filtered by activation status with pagination in a transaction.
 // Models are returned with an ascending order of model IDs.
 func ListBaseModelsByActivationStatusWithPaginationInTransaction(
@@ -199,8 +187,8 @@ func ListBaseModelsByActivationStatusWithPaginationInTransaction(
 	includeLoadingModels bool,
 ) ([]*BaseModel, bool, error) {
 	var ms []*BaseModel
-	q := tx.Joins("JOIN model_activation_statuses ON model_activation_statuses.model_id = base_models.model_id AND model_activation_statuses.tenant_id = base_models.tenant_id").
-		Where("base_models.tenant_id = ? AND model_activation_statuses.status = ?", tenantID, status)
+	q := tx.Joins("JOIN model_activation_statuses AS mas ON mas.model_id = base_models.model_id AND mas.tenant_id = base_models.tenant_id").
+		Where("base_models.tenant_id = ? AND mas.status = ?", tenantID, status)
 	if afterModelID != "" {
 		q = q.Where("base_models.model_id > ?", afterModelID)
 	}

--- a/server/internal/store/base_model.go
+++ b/server/internal/store/base_model.go
@@ -188,6 +188,8 @@ func (s *S) ListBaseModelsByActivationStatusWithPagination(
 	return ListBaseModelsByActivationStatusWithPaginationInTransaction(s.db, tenantID, status, afterModelID, limit, includeLoadingModels)
 }
 
+// ListBaseModelsByActivationStatusWithPaginationInTransaction finds base models filtered by activation status with pagination in a transaction.
+// Models are returned with an ascending order of model IDs.
 func ListBaseModelsByActivationStatusWithPaginationInTransaction(
 	tx *gorm.DB,
 	tenantID string,

--- a/server/internal/store/base_model.go
+++ b/server/internal/store/base_model.go
@@ -185,8 +185,19 @@ func (s *S) ListBaseModelsByActivationStatusWithPagination(
 	limit int,
 	includeLoadingModels bool,
 ) ([]*BaseModel, bool, error) {
+	return ListBaseModelsByActivationStatusWithPaginationInTransaction(s.db, tenantID, status, afterModelID, limit, includeLoadingModels)
+}
+
+func ListBaseModelsByActivationStatusWithPaginationInTransaction(
+	tx *gorm.DB,
+	tenantID string,
+	status v1.ActivationStatus,
+	afterModelID string,
+	limit int,
+	includeLoadingModels bool,
+) ([]*BaseModel, bool, error) {
 	var ms []*BaseModel
-	q := s.db.Joins("JOIN model_activation_statuses ON model_activation_statuses.model_id = base_models.model_id AND model_activation_statuses.tenant_id = base_models.tenant_id").
+	q := tx.Joins("JOIN model_activation_statuses ON model_activation_statuses.model_id = base_models.model_id AND model_activation_statuses.tenant_id = base_models.tenant_id").
 		Where("base_models.tenant_id = ? AND model_activation_statuses.status = ?", tenantID, status)
 	if afterModelID != "" {
 		q = q.Where("base_models.model_id > ?", afterModelID)

--- a/server/internal/store/base_model_test.go
+++ b/server/internal/store/base_model_test.go
@@ -360,13 +360,13 @@ func TestListBaseModelsByActivationStatusWithPagination(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	got, hasMore, err := st.ListBaseModelsByActivationStatusWithPagination(tenantID, v1.ActivationStatus_ACTIVATION_STATUS_ACTIVE, "", 1, true)
+	got, hasMore, err := ListBaseModelsByActivationStatusWithPaginationInTransaction(st.db, tenantID, v1.ActivationStatus_ACTIVATION_STATUS_ACTIVE, "", 1, true)
 	assert.NoError(t, err)
 	assert.Len(t, got, 1)
 	assert.True(t, hasMore)
 	assert.Equal(t, []string{"bm0"}, []string{got[0].ModelID})
 
-	got, hasMore, err = st.ListBaseModelsByActivationStatusWithPagination(tenantID, v1.ActivationStatus_ACTIVATION_STATUS_ACTIVE, "bm0", 2, true)
+	got, hasMore, err = ListBaseModelsByActivationStatusWithPaginationInTransaction(st.db, tenantID, v1.ActivationStatus_ACTIVATION_STATUS_ACTIVE, "bm0", 2, true)
 	assert.NoError(t, err)
 	assert.Len(t, got, 1)
 	assert.False(t, hasMore)

--- a/server/internal/store/base_model_test.go
+++ b/server/internal/store/base_model_test.go
@@ -360,14 +360,14 @@ func TestListBaseModelsByActivationStatusWithPagination(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	got, hasMore, err := st.ListBaseModelsByActivationStatusWithPagination(tenantID, v1.ActivationStatus_ACTIVATION_STATUS_ACTIVE, "", 2, true)
+	got, hasMore, err := st.ListBaseModelsByActivationStatusWithPagination(tenantID, v1.ActivationStatus_ACTIVATION_STATUS_ACTIVE, "", 1, true)
 	assert.NoError(t, err)
-	assert.Len(t, got, 2)
+	assert.Len(t, got, 1)
 	assert.True(t, hasMore)
-	assert.Equal(t, []string{"bm0", "bm1"}, []string{got[0].ModelID, got[1].ModelID})
+	assert.Equal(t, []string{"bm0"}, []string{got[0].ModelID})
 
-	got, hasMore, err = st.ListBaseModelsByActivationStatusWithPagination(tenantID, v1.ActivationStatus_ACTIVATION_STATUS_ACTIVE, "bm1", 2, true)
+	got, hasMore, err = st.ListBaseModelsByActivationStatusWithPagination(tenantID, v1.ActivationStatus_ACTIVATION_STATUS_ACTIVE, "bm0", 2, true)
 	assert.NoError(t, err)
-	assert.Len(t, got, 0)
+	assert.Len(t, got, 1)
 	assert.False(t, hasMore)
 }

--- a/server/internal/store/base_model_test.go
+++ b/server/internal/store/base_model_test.go
@@ -341,3 +341,33 @@ func TestUpdateBaseModel(t *testing.T) {
 	assert.Equal(t, v1.ModelLoadingStatus_MODEL_LOADING_STATUS_FAILED, m.LoadingStatus)
 	assert.Equal(t, "error", m.LoadingFailureReason)
 }
+
+func TestListBaseModelsByActivationStatusWithPagination(t *testing.T) {
+	st, tearDown := NewTest(t)
+	defer tearDown()
+
+	const tenantID = "t0"
+
+	ids := []string{"bm0", "bm1", "bm2"}
+	for i, id := range ids {
+		_, err := st.CreateBaseModel(id, "path", []v1.ModelFormat{v1.ModelFormat_MODEL_FORMAT_GGUF}, "gguf", v1.SourceRepository_SOURCE_REPOSITORY_OBJECT_STORE, tenantID)
+		assert.NoError(t, err)
+		status := v1.ActivationStatus_ACTIVATION_STATUS_ACTIVE
+		if i == 2 {
+			status = v1.ActivationStatus_ACTIVATION_STATUS_INACTIVE
+		}
+		err = st.CreateModelActivationStatus(&ModelActivationStatus{ModelID: id, TenantID: tenantID, Status: status})
+		assert.NoError(t, err)
+	}
+
+	got, hasMore, err := st.ListBaseModelsByActivationStatusWithPagination(tenantID, v1.ActivationStatus_ACTIVATION_STATUS_ACTIVE, "", 2, true)
+	assert.NoError(t, err)
+	assert.Len(t, got, 2)
+	assert.True(t, hasMore)
+	assert.Equal(t, []string{"bm0", "bm1"}, []string{got[0].ModelID, got[1].ModelID})
+
+	got, hasMore, err = st.ListBaseModelsByActivationStatusWithPagination(tenantID, v1.ActivationStatus_ACTIVATION_STATUS_ACTIVE, "bm1", 2, true)
+	assert.NoError(t, err)
+	assert.Len(t, got, 0)
+	assert.False(t, hasMore)
+}

--- a/server/internal/store/model.go
+++ b/server/internal/store/model.go
@@ -131,19 +131,6 @@ func (s *S) ListModelsByProjectIDWithPagination(
 	return ms, hasMore, nil
 }
 
-// ListModelsByActivationStatusWithPagination finds models filtered by activation status with pagination.
-// Models are returned with an ascending order of model IDs.
-func (s *S) ListModelsByActivationStatusWithPagination(
-	projectID string,
-	onlyPublished bool,
-	status v1.ActivationStatus,
-	afterModelID string,
-	limit int,
-	includeLoadingModels bool,
-) ([]*Model, bool, error) {
-	return ListModelsByActivationStatusWithPaginationInTransaction(s.db, projectID, onlyPublished, status, afterModelID, limit, includeLoadingModels)
-}
-
 // ListModelsByActivationStatusWithPaginationInTransaction finds models filtered by activation status with pagination in a transaction.
 // Models are returned with an ascending order of model IDs.
 func ListModelsByActivationStatusWithPaginationInTransaction(

--- a/server/internal/store/model.go
+++ b/server/internal/store/model.go
@@ -141,8 +141,20 @@ func (s *S) ListModelsByActivationStatusWithPagination(
 	limit int,
 	includeLoadingModels bool,
 ) ([]*Model, bool, error) {
+	return ListModelsByActivationStatusWithPaginationInTransaction(s.db, projectID, onlyPublished, status, afterModelID, limit, includeLoadingModels)
+}
+
+func ListModelsByActivationStatusWithPaginationInTransaction(
+	tx *gorm.DB,
+	projectID string,
+	onlyPublished bool,
+	status v1.ActivationStatus,
+	afterModelID string,
+	limit int,
+	includeLoadingModels bool,
+) ([]*Model, bool, error) {
 	var ms []*Model
-	q := s.db.Joins("JOIN model_activation_statuses AS mas ON mas.model_id = models.model_id AND mas.tenant_id = models.tenant_id").
+	q := tx.Joins("JOIN model_activation_statuses AS mas ON mas.model_id = models.model_id AND mas.tenant_id = models.tenant_id").
 		Where("models.project_id = ? AND mas.status = ?", projectID, status)
 	if onlyPublished {
 		q = q.Where("models.is_published = true")

--- a/server/internal/store/model.go
+++ b/server/internal/store/model.go
@@ -144,6 +144,8 @@ func (s *S) ListModelsByActivationStatusWithPagination(
 	return ListModelsByActivationStatusWithPaginationInTransaction(s.db, projectID, onlyPublished, status, afterModelID, limit, includeLoadingModels)
 }
 
+// ListModelsByActivationStatusWithPaginationInTransaction finds models filtered by activation status with pagination in a transaction.
+// Models are returned with an ascending order of model IDs.
 func ListModelsByActivationStatusWithPaginationInTransaction(
 	tx *gorm.DB,
 	projectID string,

--- a/server/internal/store/model.go
+++ b/server/internal/store/model.go
@@ -131,6 +131,40 @@ func (s *S) ListModelsByProjectIDWithPagination(
 	return ms, hasMore, nil
 }
 
+// ListModelsByActivationStatusWithPagination finds models filtered by activation status with pagination.
+// Models are returned with an ascending order of model IDs.
+func (s *S) ListModelsByActivationStatusWithPagination(
+	projectID string,
+	onlyPublished bool,
+	status v1.ActivationStatus,
+	afterModelID string,
+	limit int,
+	includeLoadingModels bool,
+) ([]*Model, bool, error) {
+	var ms []*Model
+	q := s.db.Joins("JOIN model_activation_statuses ON model_activation_statuses.model_id = models.model_id AND model_activation_statuses.tenant_id = models.tenant_id").
+		Where("models.project_id = ? AND model_activation_statuses.status = ?", projectID, status)
+	if onlyPublished {
+		q = q.Where("models.is_published = true")
+	}
+	if afterModelID != "" {
+		q = q.Where("models.model_id > ?", afterModelID)
+	}
+	if !includeLoadingModels {
+		q = q.Where("(models.loading_status is null OR models.loading_status = ?)", v1.ModelLoadingStatus_MODEL_LOADING_STATUS_SUCCEEDED)
+	}
+	if err := q.Order("models.model_id").Limit(limit + 1).Find(&ms).Error; err != nil {
+		return nil, false, err
+	}
+
+	var hasMore bool
+	if len(ms) > limit {
+		ms = ms[:limit]
+		hasMore = true
+	}
+	return ms, hasMore, nil
+}
+
 // ListUnloadedModels returns all unloaded base models with the requested loading status.
 func (s *S) ListUnloadedModels(tenantID string) ([]*Model, error) {
 	var ms []*Model

--- a/server/internal/store/model.go
+++ b/server/internal/store/model.go
@@ -142,8 +142,8 @@ func (s *S) ListModelsByActivationStatusWithPagination(
 	includeLoadingModels bool,
 ) ([]*Model, bool, error) {
 	var ms []*Model
-	q := s.db.Joins("JOIN model_activation_statuses ON model_activation_statuses.model_id = models.model_id AND model_activation_statuses.tenant_id = models.tenant_id").
-		Where("models.project_id = ? AND model_activation_statuses.status = ?", projectID, status)
+	q := s.db.Joins("JOIN model_activation_statuses AS mas ON mas.model_id = models.model_id AND mas.tenant_id = models.tenant_id").
+		Where("models.project_id = ? AND mas.status = ?", projectID, status)
 	if onlyPublished {
 		q = q.Where("models.is_published = true")
 	}

--- a/server/internal/store/model_activation_status.go
+++ b/server/internal/store/model_activation_status.go
@@ -32,8 +32,13 @@ func CreateModelActivationStatusInTransaction(tx *gorm.DB, status *ModelActivati
 
 // GetModelActivationStatus retrieves the model activation status.
 func (s *S) GetModelActivationStatus(modelID, tenantID string) (*ModelActivationStatus, error) {
+	return GetModelActivationStatusInTransaction(s.db, modelID, tenantID)
+}
+
+// GetModelActivationStatusInTransaction retrieves the model activation status in a transaction.
+func GetModelActivationStatusInTransaction(tx *gorm.DB, modelID, tenantID string) (*ModelActivationStatus, error) {
 	status := &ModelActivationStatus{}
-	if err := s.db.Where("model_id = ? AND tenant_id = ?", modelID, tenantID).First(status).Error; err != nil {
+	if err := tx.Where("model_id = ? AND tenant_id = ?", modelID, tenantID).First(status).Error; err != nil {
 		return nil, err
 	}
 

--- a/server/internal/store/model_test.go
+++ b/server/internal/store/model_test.go
@@ -309,13 +309,13 @@ func TestListModelsByActivationStatusWithPagination(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	got, hasMore, err := st.ListModelsByActivationStatusWithPagination(projectID, true, v1.ActivationStatus_ACTIVATION_STATUS_ACTIVE, "", 1, true)
+	got, hasMore, err := ListModelsByActivationStatusWithPaginationInTransaction(st.db, projectID, true, v1.ActivationStatus_ACTIVATION_STATUS_ACTIVE, "", 1, true)
 	assert.NoError(t, err)
 	assert.Len(t, got, 1)
 	assert.True(t, hasMore)
 	assert.Equal(t, []string{ids[0]}, []string{got[0].ModelID})
 
-	got, hasMore, err = st.ListModelsByActivationStatusWithPagination(projectID, true, v1.ActivationStatus_ACTIVATION_STATUS_ACTIVE, ids[0], 2, true)
+	got, hasMore, err = ListModelsByActivationStatusWithPaginationInTransaction(st.db, projectID, true, v1.ActivationStatus_ACTIVATION_STATUS_ACTIVE, ids[0], 2, true)
 	assert.NoError(t, err)
 	assert.Len(t, got, 1)
 	assert.False(t, hasMore)

--- a/server/internal/store/model_test.go
+++ b/server/internal/store/model_test.go
@@ -309,14 +309,15 @@ func TestListModelsByActivationStatusWithPagination(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	got, hasMore, err := st.ListModelsByActivationStatusWithPagination(projectID, true, v1.ActivationStatus_ACTIVATION_STATUS_ACTIVE, "", 2, true)
+	got, hasMore, err := st.ListModelsByActivationStatusWithPagination(projectID, true, v1.ActivationStatus_ACTIVATION_STATUS_ACTIVE, "", 1, true)
 	assert.NoError(t, err)
-	assert.Len(t, got, 2)
+	assert.Len(t, got, 1)
 	assert.True(t, hasMore)
-	assert.Equal(t, []string{"m0", "m1"}, []string{got[0].ModelID, got[1].ModelID})
+	assert.Equal(t, []string{ids[0]}, []string{got[0].ModelID})
 
-	got, hasMore, err = st.ListModelsByActivationStatusWithPagination(projectID, true, v1.ActivationStatus_ACTIVATION_STATUS_ACTIVE, "m1", 2, true)
+	got, hasMore, err = st.ListModelsByActivationStatusWithPagination(projectID, true, v1.ActivationStatus_ACTIVATION_STATUS_ACTIVE, ids[0], 2, true)
 	assert.NoError(t, err)
-	assert.Len(t, got, 0)
+	assert.Len(t, got, 1)
 	assert.False(t, hasMore)
+	assert.Equal(t, []string{ids[1]}, []string{got[0].ModelID})
 }

--- a/server/internal/store/model_test.go
+++ b/server/internal/store/model_test.go
@@ -279,3 +279,44 @@ func TestLoadingStatus(t *testing.T) {
 	assert.Equal(t, v1.ModelLoadingStatus_MODEL_LOADING_STATUS_FAILED, got.LoadingStatus)
 	assert.Equal(t, "fake-error", got.LoadingFailureReason)
 }
+
+func TestListModelsByActivationStatusWithPagination(t *testing.T) {
+	st, tearDown := NewTest(t)
+	defer tearDown()
+
+	const (
+		tenantID  = "tid0"
+		orgID     = "org0"
+		projectID = "project0"
+	)
+
+	ids := []string{"m0", "m1", "m2"}
+	for i, id := range ids {
+		_, err := st.CreateModel(ModelSpec{
+			ModelID:        id,
+			TenantID:       tenantID,
+			OrganizationID: orgID,
+			ProjectID:      projectID,
+			Path:           "path",
+			IsPublished:    true,
+		})
+		assert.NoError(t, err)
+		status := v1.ActivationStatus_ACTIVATION_STATUS_ACTIVE
+		if i == 2 {
+			status = v1.ActivationStatus_ACTIVATION_STATUS_INACTIVE
+		}
+		err = st.CreateModelActivationStatus(&ModelActivationStatus{ModelID: id, TenantID: tenantID, Status: status})
+		assert.NoError(t, err)
+	}
+
+	got, hasMore, err := st.ListModelsByActivationStatusWithPagination(projectID, true, v1.ActivationStatus_ACTIVATION_STATUS_ACTIVE, "", 2, true)
+	assert.NoError(t, err)
+	assert.Len(t, got, 2)
+	assert.True(t, hasMore)
+	assert.Equal(t, []string{"m0", "m1"}, []string{got[0].ModelID, got[1].ModelID})
+
+	got, hasMore, err = st.ListModelsByActivationStatusWithPagination(projectID, true, v1.ActivationStatus_ACTIVATION_STATUS_ACTIVE, "m1", 2, true)
+	assert.NoError(t, err)
+	assert.Len(t, got, 0)
+	assert.False(t, hasMore)
+}


### PR DESCRIPTION
This is the code generated by OpenAI Codex for the following prompt:

"
I want to improve the default way that models are sorted when returned from ListModel() in model-manager/blob/main/server/internal/server/models.go. Currently they are returned in the order of:
1)Base models
2)Fine tuned models

I want them to be returned in the order of:
1)Active Base Models
2)Active Fine Tuned models
3)Inactive Base Models
4)Inactive Fine tuned Models

Please improve the ListModels function to behave as described above, and create associated tests
"

The code looks better to me than Jules' solution personally, but open towhat others think. It seems like Codex took more of the existing coding style into account than Jules