### PR TITLE
fix: return a NotFound error when a model is not loaded

### DIFF
--- a/server/internal/server/ws_models.go
+++ b/server/internal/server/ws_models.go
@@ -399,7 +399,7 @@ func (s *WS) GetBaseModelPath(
 			return nil, status.Errorf(codes.Internal, "get base model: %s", err)
 		}
 		if !isBaseModelLoaded(m) {
-			return nil, status.Error(codes.FailedPrecondition, "model is not loaded")
+			return nil, status.Errorf(codes.NotFound, "model %q not found", req.Id)
 		}
 	} else {
 		var found bool


### PR DESCRIPTION
model-manager-loader uses this RPC to check if the model has been loaded.