### PR TITLE
fix: do not validate the model config on update

### DIFF
--- a/server/internal/server/models.go
+++ b/server/internal/server/models.go
@@ -446,10 +446,6 @@ func (s *S) UpdateModel(
 		return nil, status.Error(codes.InvalidArgument, "id is required")
 	}
 
-	if err := validateModelConfig(req.Model.Config); err != nil {
-		return nil, err
-	}
-
 	// Currently only support the update of the config field.
 	if req.UpdateMask == nil {
 		return nil, status.Error(codes.InvalidArgument, "update mask is required")


### PR DESCRIPTION
The "config" field is used for patching and it is not fully populated.