### PR TITLE
fix(build): bump the base image to `golang:1.25`

### DIFF
--- a/build/loader/Dockerfile
+++ b/build/loader/Dockerfile
@@ -1,5 +1,5 @@
 FROM --platform=$BUILDPLATFORM ollama/ollama AS ollama
-FROM --platform=$BUILDPLATFORM golang:1.23 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
 ARG TARGETARCH
 
 WORKDIR /workspace

--- a/build/server/Dockerfile
+++ b/build/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.23 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
 ARG TARGETARCH
 
 WORKDIR /workspace


### PR DESCRIPTION
`go` directive in `go.mod` has been bumped by https://github.com/llmariner/model-manager/commit/809683aa7d6def0e3c063e72f2f6cf48a85796b6#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6